### PR TITLE
feat: 新增 Portable-Web 便携版（不含 .NET 运行时）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,11 @@ jobs:
           --filter "FullyQualifiedName!~SevenZipEngine"
           --logger "console;verbosity=normal"
 
-      - name: Publish (framework-dependent)
+      - name: Publish (framework-dependent, win-x64)
         run: >
           dotnet publish src\MantisZip.UI\MantisZip.UI.csproj
           --no-restore --configuration Release
+          --runtime win-x64
           --output publish_output
           -p:DebugType=portable
           -p:DebugSymbols=true
@@ -120,7 +121,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "ISCC compilation failed (exit code: $LASTEXITCODE)" }
           Write-Host "Self-contained installer built successfully"
 
-      - name: Package portable zip
+      - name: Package portable zip (self-contained)
         shell: pwsh
         run: |
           $src = "publish_output_selfcontained"
@@ -136,9 +137,39 @@ jobs:
           } else {
             Write-Host "7z.dll not found, 7z compression will not be available"
           }
+          # Strip .NET runtime satellite assemblies (cs, de, es, fr, it, ja, ko,
+          # pl, pt-BR, ru, tr) — they're unused by MantisZip's JSON-based i18n
+          $runtimeLocales = @("cs","de","es","fr","it","ja","ko","pl","pt-BR","ru","tr")
+          foreach ($locale in $runtimeLocales) {
+            $localeDir = Join-Path $src $locale
+            if (Test-Path $localeDir) {
+              Remove-Item -Recurse -Force $localeDir
+              Write-Host "Stripped runtime locale: $locale"
+            }
+          }
           $zipName = "MantisZip-$env:VERSION-Portable.zip"
           Compress-Archive -Path "$src\*" -DestinationPath $zipName -CompressionLevel Optimal
           Write-Host "Portable zip created: $zipName ($((Get-Item $zipName).Length / 1MB -as [int]) MB)"
+
+      - name: Package portable web zip (framework-dependent)
+        shell: pwsh
+        run: |
+          $src = "publish_output"
+          # Portable.txt sentinel file
+          "" | Out-File -FilePath "$src\Portable.txt" -Encoding ascii
+          # Copy 7z.dll for 7z compression support
+          $sevenZ = "$env:ProgramFiles\7-Zip\7z.dll"
+          if (Test-Path $sevenZ) {
+            $x64Dir = "$src\x64"
+            New-Item -ItemType Directory -Path $x64Dir -Force | Out-Null
+            Copy-Item $sevenZ "$x64Dir\7z.dll"
+            Write-Host "7z.dll copied to x64 subdirectory"
+          } else {
+            Write-Host "7z.dll not found, 7z compression will not be available"
+          }
+          $zipName = "MantisZip-$env:VERSION-Portable-Web.zip"
+          Compress-Archive -Path "$src\*" -DestinationPath $zipName -CompressionLevel Optimal
+          Write-Host "Portable web zip created: $zipName ($((Get-Item $zipName).Length / 1MB -as [int]) MB)"
 
       - name: List installer artifacts
         shell: pwsh
@@ -171,7 +202,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           $installers = Get-ChildItem -Path installer -Filter "*.exe" | ForEach-Object FullName
-          $portableZip = Get-ChildItem -Filter "*-Portable.zip" | ForEach-Object FullName
+          $portableZip = Get-ChildItem -Filter "*-Portable*.zip" | ForEach-Object FullName
           $assets = $installers + $portableZip
           if (-not $assets) { throw "No release assets found" }
           $notes = Get-Content release_notes.txt -Raw

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -46,6 +46,20 @@
    - `App.OnExit`：清理指向 `Data/Temp/` 而非系统 `%TEMP%`
 2. **修改文件（6 个）**：`AppSettings.cs`、`PasswordManager.cs`、`App.xaml.cs`、`MainWindow.Preview.cs`、`MainWindow.DragDrop.cs`、`SevenZipEngine.cs`
 
+### v0.4.5++ (2026-07-14) 新增 Portable-Web 便携版
+
+1. **新增 Portable-Web 便携版** — release.yml 新增 `Package portable web zip` 步骤
+   - `publish_output`（framework-dependent）打包为 `MantisZip-{version}-Portable-Web.zip`
+   - 不捆绑 .NET 运行时，体积大幅减小，用户需自行安装 .NET 9 Runtime
+   - 原有的 self-contained Portable zip 保持不变
+   - 关联 issue #28
+2. **剥离非 Windows 运行时库** — framework-dependent 发布增加 `--runtime win-x64`，仅保留 win-x64 的原生资产
+   - `runtimes/` 从 31 MB 减到 ~1.9 MB（仅 win-x64/native）
+   - Portable-Web zip 从 28 MB 降为 ~13 MB
+3. **剥离 .NET 运行时卫星语言程序集** — self-contained 便携版打包时删除 `cs/de/es/fr/it/ja/ko/pl/pt-BR/ru/tr` 目录
+   - Portable zip 减少 ~15 MB 无用体积
+   - MantisZip 使用 JSON 文件实现国际化，不依赖 .NET 卫星程序集
+
 ### v0.4.5++ (2026-07-14) 文件过滤预设显示 + 过滤统计文本始终显示
 
 1. **修复预设 ComboBox 显示类型名** — `FileFilterPreset` 添加 `ToString()` 返回 `Name`，确保预设名称正确显示


### PR DESCRIPTION
- Framework-dependent 发布增加 --runtime win-x64，剥离非 Windows 运行时库
- 新增 Package portable web zip 步骤，生成 Portable-Web.zip（13 MB）
- Self-contained Portable zip 打包时剥离 .NET 运行时卫星语言程序集（-15 MB）
- 修复 Create Release 的 glob 匹配漏掉 -Portable-Web.zip 的问题

Closes #28